### PR TITLE
OpenMetadata does not support creating tables

### DIFF
--- a/pkg/openmetadata-connector-core/connector_helper.go
+++ b/pkg/openmetadata-connector-core/connector_helper.go
@@ -531,6 +531,9 @@ func (s *OpenMetadataAPIService) createTable(ctx context.Context,
 	databaseSchemaID string,
 	tableName string,
 	columns []client.Column) (*client.Table, error) {
+	if len(columns) == 0 {
+		columns = append(columns, *client.NewColumn("STRING", "fake_column"))
+	}
 	createTable := client.NewCreateTable(columns,
 		*client.NewEntityReference(databaseSchemaID, "databaseSchema"),
 		tableName)


### PR DESCRIPTION
without specifying columns.
Adding a fake column when none are specified

Signed-off-by: Doron Chen <cdoron@il.ibm.com>